### PR TITLE
Validate stristr needle

### DIFF
--- a/lib/Minify/Minify/IgnoredCommentPreserver.php
+++ b/lib/Minify/Minify/IgnoredCommentPreserver.php
@@ -39,7 +39,7 @@ class Minify_IgnoredCommentPreserver {
 
     protected function _isIgnoredComment(&$comment) {
         foreach ($this->_ignoredComments as $ignoredComment) {
-            if (stristr($comment, $ignoredComment) !== false) {
+            if (!empty($ignoredComment) && stristr($comment, $ignoredComment) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
Search needle was empty sometimes, causing error logs to grow. Validating the needle being passed to the stristr function fixes it.
